### PR TITLE
Fix behavior when `host_tag=Falsey`

### DIFF
--- a/potsdb/client.py
+++ b/potsdb/client.py
@@ -98,6 +98,8 @@ class Client():
             self.host_tag = socket.gethostname()
         elif isinstance(host_tag, str):
             self.host_tag = host_tag
+        else:
+            self.host_tag = None
 
         self.t = threading.Thread(target=_push,
                                   args=(host, self.port, self.q, self.done, mps, self._stop, test_mode))


### PR DESCRIPTION
```
>>> import potsdb
>>> metrics = potsdb.Client('localhost', host_tag=None, mps=1000)
>>> metrics.send('test.metric', 100, tag='foo', tag2='bar')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/export/hdi3/home/pl/.virtualenvs/opentsdb/lib/python2.7/site-packages/potsdb/client.py", line 121, in log
    if self.host_tag and 'host' not in tags:
AttributeError: Client instance has no attribute 'host_tag'
```
